### PR TITLE
Fix code scanning alert no. 14: Incomplete string escaping or encoding

### DIFF
--- a/src/mode/odin_highlight_rules.js
+++ b/src/mode/odin_highlight_rules.js
@@ -115,7 +115,7 @@ var OdinHighlightRules = function () {
         token: "constant.numeric", // rune
         regex:
           "'(?:[^\\'\uD800-\uDBFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|" +
-          stringEscapeRe.replace('"', "") +
+          stringEscapeRe.replace(/"/g, "") +
           ")'"
       },
       {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ace/security/code-scanning/14](https://github.com/cooljeanius/ace/security/code-scanning/14)

To fix the problem, we need to ensure that all occurrences of the double-quote character are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of the double-quote character is replaced, thus providing complete escaping.

- Modify the `replace` method call to use a regular expression with the global flag.
- Specifically, change the line `stringEscapeRe.replace('"', "")` to `stringEscapeRe.replace(/"/g, "")`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
