### PR TITLE
Fix code scanning alert no. 13: Incomplete string escaping or encoding

### DIFF
--- a/src/mode/golang_highlight_rules.js
+++ b/src/mode/golang_highlight_rules.js
@@ -47,7 +47,7 @@ var oop = require("../lib/oop");
                     next : "bqstring"
                 }, {
                     token : "constant.numeric", // rune
-                    regex : "'(?:[^\\'\uD800-\uDBFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|" + stringEscapeRe.replace('"', '')  + ")'"
+                    regex : "'(?:[^\\'\uD800-\uDBFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|" + stringEscapeRe.replace(/"/g, '')  + ")'"
                 }, {
                     token : "constant.numeric", // hex
                     regex : "0[xX][0-9a-fA-F]+\\b" 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ace/security/code-scanning/13](https://github.com/cooljeanius/ace/security/code-scanning/13)

To fix the problem, we need to ensure that all occurrences of the double-quote character are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we should replace `stringEscapeRe.replace('"', '')` with `stringEscapeRe.replace(/"/g, '')`.

- **How to fix the problem:** Use a regular expression with the global flag to replace all occurrences of the double-quote character.
- **Detailed description:** Modify the line where `stringEscapeRe.replace('"', '')` is used to `stringEscapeRe.replace(/"/g, '')`.
- **Specific changes:** Update line 50 in the file `src/mode/golang_highlight_rules.js`.
- **Needed:** No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
