### PR TITLE
Fix code scanning alert no. 12: Incomplete string escaping or encoding

### DIFF
--- a/src/keyboard/vim.js
+++ b/src/keyboard/vim.js
@@ -6596,7 +6596,7 @@ domLib.importCssString(`.normal-mode .ace_cursor{
             if (getOption('pcre')) {
                regexPart = regexPart + '/' + flagsPart;
             } else {
-               regexPart = regexPart.replace(/\//g, "\\/") + '/' + flagsPart;
+               regexPart = regexPart.replace(/\\/g, "\\\\").replace(/\//g, "\\/") + '/' + flagsPart;
             }
           }
         }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ace/security/code-scanning/12](https://github.com/cooljeanius/ace/security/code-scanning/12)

To fix the problem, we need to ensure that all backslashes in `regexPart` are properly escaped before it is used to construct a regular expression. This can be done by replacing each backslash (`\`) with a double backslash (`\\`). This ensures that the backslashes are treated as literal characters in the regular expression.

- We will modify the line where `regexPart.replace` is called to include an additional replace operation that escapes backslashes.
- Specifically, we will change the line `regexPart = regexPart.replace(/\//g, "\\/") + '/' + flagsPart;` to `regexPart = regexPart.replace(/\\/g, "\\\\").replace(/\//g, "\\/") + '/' + flagsPart;`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
