### PR TITLE
Fix code scanning alert no. 11: Incomplete string escaping or encoding

### DIFF
--- a/doc/template/resources/javascripts/ux.js
+++ b/doc/template/resources/javascripts/ux.js
@@ -117,7 +117,7 @@ function scrollTo(el, data) {
         data = el.getAttribute("data-id");
         //location.hash = data;
     }
-    var el = $("span#" + data.replace(/\./g, "\\."))[0];
+    var el = $("span#" + data.replace(/\\/g, "\\\\").replace(/\./g, "\\."))[0];
     if (!el) return;
 
     var article = $(el).closest('.article')[0];


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ace/security/code-scanning/11](https://github.com/cooljeanius/ace/security/code-scanning/11)

To fix the problem, we need to ensure that backslashes in the `data` string are properly escaped before replacing periods with escaped periods. This can be achieved by first replacing backslashes with double backslashes and then replacing periods with escaped periods. This ensures that any backslashes in the input are correctly handled.

1. Modify the `data.replace` call on line 120 to first escape backslashes.
2. Use a regular expression with the global flag to replace all occurrences of backslashes and periods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
