### PR TITLE
Fix code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/doc/site/js/main.js
+++ b/doc/site/js/main.js
@@ -78,7 +78,8 @@ $(function() {
             // handles dropping in from new link
             var section = $.bbq.getState("section");
             if (section) {
-                $("li#dropdown_" + section.replace(/\./g, '\\.') + " a").triggerHandler('click');
+                section = section.replace(/\\/g, '\\\\').replace(/\./g, '\\.');
+                $("li#dropdown_" + section + " a").triggerHandler('click');
             }
             
             //setupDisqus(_self.attr("href"));


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ace/security/code-scanning/9](https://github.com/cooljeanius/ace/security/code-scanning/9)

To fix the problem, we need to ensure that all backslashes in the `section` variable are properly escaped before using it in a jQuery selector. This can be achieved by using a regular expression with the global flag to replace all occurrences of backslashes with double backslashes. Additionally, we should ensure that periods are also escaped correctly.

- We will modify the `section.replace` call to first escape backslashes and then escape periods.
- The changes will be made on line 81 of the file `doc/site/js/main.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
