### PR TITLE
Fix code scanning alert no. 7: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
         "requirePragma": false,
         "insertPragma": false,
         "proseWrap": "preserve"
-    }
+    },
+    "dependencies": {
+    "htmlparser2": "^9.1.0"
+  }
 }

--- a/src/mode/logiql.js
+++ b/src/mode/logiql.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var oop = require("../lib/oop");
+var htmlparser2 = require("htmlparser2");
 var TextMode = require("./text").Mode;
 var LogiQLHighlightRules = require("./logiql_highlight_rules").LogiQLHighlightRules;
 var FoldMode = require("./folding/coffee").FoldMode;
@@ -32,7 +33,7 @@ oop.inherits(Mode, TextMode);
             return indent;
 
         var match = line.match();
-        if (/(-->|<--|<-|->|{)\s*$/.test(line))
+        if (this.isCommentEndTag(line))
             indent += tab;
         return indent;
     };
@@ -99,6 +100,17 @@ oop.inherits(Mode, TextMode);
         var col = it.getCurrentTokenColumn();
         var row = it.getCurrentTokenRow();
         return new Range(row, col, row, col + tok.value.length);
+    };
+    this.isCommentEndTag = function(line) {
+        var isEndTag = false;
+        var parser = new htmlparser2.Parser({
+            oncommentend() {
+                isEndTag = true;
+            }
+        });
+        parser.write(line);
+        parser.end();
+        return isEndTag;
     };
     this.$id = "ace/mode/logiql";
 }).call(Mode.prototype);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ace/security/code-scanning/7](https://github.com/cooljeanius/ace/security/code-scanning/7)

To fix the problem, we should replace the custom regular expression with a more robust solution that can handle various HTML comment end tags. The best way to achieve this is by using a well-tested library like `htmlparser2` to parse the HTML and identify comment end tags correctly. This approach ensures that all edge cases are handled without relying on custom regular expressions.

1. Install the `htmlparser2` library.
2. Replace the custom regular expression with a function that uses `htmlparser2` to parse the HTML and identify comment end tags.
3. Update the relevant code sections to use the new function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
