### PR TITLE
Fix code scanning alert no. 26: Useless regular-expression character escape

### DIFF
--- a/src/mode/r.js
+++ b/src/mode/r.js
@@ -58,7 +58,7 @@
       // todo import codeModel from RStudio
       this.tokenRe = new RegExp("^[" + unicode.wordChars + "._]+", "g");
 
-      this.nonTokenRe = new RegExp("^(?:[^" + unicode.wordChars + "._]|\s])+", "g");
+      this.nonTokenRe = new RegExp("^(?:[^" + unicode.wordChars + "._]|\\s])+", "g");
 
       /*this.$complements = {
                "(": ")",


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ace/security/code-scanning/26](https://github.com/cooljeanius/ace/security/code-scanning/26)

To fix the problem, we need to ensure that the `\s` escape sequence is correctly interpreted as a whitespace character class within the string literal. This requires escaping the backslash itself, resulting in `\\s`. This change will ensure that the regular expression behaves as intended.

- Change the string literal on line 61 to use `\\s` instead of `\s`.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
