### PR TITLE
Potential fix for code scanning alert no. 256: Uncontrolled data used in path expression

### DIFF
--- a/static.js
+++ b/static.js
@@ -41,7 +41,12 @@ http.createServer(function(req, res) {
         return error(res, 400, "400 Bad request: Directory traversal is not allowed.");
     }
 
-    var filename = path.join(process.cwd(), uri);
+    var rootDir = process.cwd();
+    var filename = path.resolve(rootDir, "." + uri);
+    var relativePath = path.relative(rootDir, filename);
+    if (path.isAbsolute(relativePath) || relativePath.startsWith("..") || relativePath.indexOf(".." + path.sep) === 0) {
+        return error(res, 400, "400 Bad request: Directory traversal is not allowed.");
+    }
 
     if (req.method == "OPTIONS") {
         writeHead(res, 200);


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/ace/security/code-scanning/256](https://github.com/cooljeanius/ace/security/code-scanning/256)

General fix: derive a trusted root directory (`process.cwd()`), resolve the user path against it with `path.resolve`, and reject the request unless the resolved path is inside the root. Use `path.relative(root, resolved)` (or equivalent) to enforce containment in a cross-platform safe way.

Best fix here (without changing intended functionality): in `static.js`, replace direct `path.join(process.cwd(), uri)` with a resolved path plus a containment check. If invalid, return HTTP 400 before any filesystem action. This protects both read (`fs.stat`, `createReadStream`) and write (`save` -> `writeFileSync`) flows because both use `filename`.

Changes needed:
- In the request handler around lines 44–45, introduce:
  - `var rootDir = process.cwd();`
  - `var filename = path.resolve(rootDir, "." + uri);`
  - `var relativePath = path.relative(rootDir, filename);`
  - rejection when `relativePath` is absolute or starts with `".."`.
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
