### PR TITLE
Potential fix for code scanning alert no. 32: DOM text reinterpreted as HTML

### DIFF
--- a/doc/template/resources/javascripts/bootstrap.js
+++ b/doc/template/resources/javascripts/bootstrap.js
@@ -209,7 +209,7 @@
 
       if (e.isDefaultPrevented()) return
 
-      $target = $(selector)
+      $target = $($.find(selector))
 
       this.activate($this.parent('li'), $ul)
       this.activate($target, $target.parent(), function () {


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/ace/security/code-scanning/32](https://github.com/cooljeanius/ace/security/code-scanning/32)

Use a selector-only API so untrusted text is never interpreted as HTML.  
In this file, the best minimal fix is to replace `$(selector)` with `$.find(selector)` wrapped as a jQuery object: `$( $.find(selector) )`. This preserves behavior (finding target elements by CSS selector) while preventing jQuery from treating the input as HTML.

Edit region in `doc/template/resources/javascripts/bootstrap.js` inside `Tab.prototype.show`, around line 212:
- Change assignment of `$target` from `$(selector)` to `$( $.find(selector) )`.
- No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
