### PR TITLE
Potential fix for code scanning alert no. 31: DOM text reinterpreted as HTML

### DIFF
--- a/doc/template/resources/javascripts/bootstrap.js
+++ b/doc/template/resources/javascripts/bootstrap.js
@@ -113,7 +113,7 @@
       selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
     }
 
-    $parent = $(selector)
+    $parent = $($.find(selector))
     $parent.length || ($parent = $this.parent())
 
     return $parent


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/ace/security/code-scanning/31](https://github.com/cooljeanius/ace/security/code-scanning/31)

Use a selector-only API instead of the generic `$()` constructor for untrusted selector text.

Best fix in this snippet: in `getParent($this)`, replace `$(selector)` with `$.find(selector)` wrapped by `$` (so behavior remains a jQuery object), i.e. `$($.find(selector))`. `$.find` treats input as a CSS selector and does not reinterpret it as HTML, which addresses the CodeQL finding while preserving dropdown parent lookup behavior.

Edit region:
- **File:** `doc/template/resources/javascripts/bootstrap.js`
- **Function:** `getParent($this)`
- **Line:** current sink at line 116.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
